### PR TITLE
fix: Deprecated `CommentPlugin.removeTags` usage

### DIFF
--- a/typedoc-plugin-internal-external.ts
+++ b/typedoc-plugin-internal-external.ts
@@ -87,8 +87,8 @@ export class InternalExternalPlugin extends ConverterComponent {
       InternalExternalPlugin.markSignatureAndMethod(reflection, true);
     }
 
-    this.internals.forEach(tag => CommentPlugin.removeTags(comment, tag));
-    this.externals.forEach(tag => CommentPlugin.removeTags(comment, tag));
+    this.internals.forEach(tag => comment.removeTags(tag));
+    this.externals.forEach(tag => comment.removeTags(tag));
   }
 
   /**
@@ -110,8 +110,8 @@ export class InternalExternalPlugin extends ConverterComponent {
       setExternal(reflection.flags, true);
     }
 
-    this.internals.forEach(tag => CommentPlugin.removeTags(comment, tag));
-    this.externals.forEach(tag => CommentPlugin.removeTags(comment, tag));
+    this.internals.forEach(tag => comment.removeTags(tag));
+    this.externals.forEach(tag => comment.removeTags(tag));
   }
 
   /**


### PR DESCRIPTION
See https://github.com/TypeStrong/typedoc/blob/master/src/lib/converter/plugins/CommentPlugin.ts#L354